### PR TITLE
feat(menuCategories): add  endpoints to handle menu categories

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,10 @@ import { ConfigService } from './modules/config/config.service';
 import { DatabaseModule } from './modules/database/database.module';
 import { UserModule } from './modules/user/user.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { MenuCategoryModule } from './modules/menu-category/menu-category.module';
 
 @Module({
-  imports: [ConfigModule, DatabaseModule, UserModule, AuthModule],
+  imports: [ConfigModule, DatabaseModule, UserModule, AuthModule, MenuCategoryModule],
 })
 export class AppModule {
   static PORT: number | string;

--- a/src/modules/database/migrations/1605857035429-create_menu_categories_table.ts
+++ b/src/modules/database/migrations/1605857035429-create_menu_categories_table.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class createMenuCategoriesTable1605857035429 implements MigrationInterface {
+    name = 'createMenuCategoriesTable1605857035429'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "menu_categories" ("id" SERIAL NOT NULL, "name" character varying(50) NOT NULL, "author_id" integer, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_124ae987900336f983881cb04e6" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "menu_categories"`);
+    }
+
+}

--- a/src/modules/menu-category/dto/create-menu-category.dto.ts
+++ b/src/modules/menu-category/dto/create-menu-category.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreateMenuCategoryDto {
+  @ApiProperty({ description: 'The menu category name', required: true })
+  @IsString({ message: 'menu_category_name_required' })
+  name: string;
+}

--- a/src/modules/menu-category/dto/response-menu-category.dto.ts
+++ b/src/modules/menu-category/dto/response-menu-category.dto.ts
@@ -1,0 +1,15 @@
+import { Exclude, Expose } from "class-transformer";
+
+@Exclude()
+export class ResponseMenuCategoryDto {
+  @Expose()
+  id: number;
+  @Expose()
+  name: string;
+  @Expose()
+  authorId: number;
+  @Expose()
+  createdAt: Date;
+  @Expose()
+  updatedAt: Date;
+}

--- a/src/modules/menu-category/dto/update-menu-category.dto.ts
+++ b/src/modules/menu-category/dto/update-menu-category.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class UpdateMenuCategoryDto {
+  @ApiProperty({ description: 'The menu category name', required: true })
+  @IsString({ message: 'menu_category_name_required' })
+  name: string;
+}

--- a/src/modules/menu-category/menu-category.controller.ts
+++ b/src/modules/menu-category/menu-category.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Post, Body, Put, Param, UseGuards } from '@nestjs/common';
+import { MenuCategoryService } from './menu-category.service';
+import { CreateMenuCategoryDto } from './dto/create-menu-category.dto';
+import { UpdateMenuCategoryDto } from './dto/update-menu-category.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+
+@ApiTags('The menus categories')
+@Controller('menu-categories')
+export class MenuCategoryController {
+  constructor(private readonly _menuCategoryService: MenuCategoryService) {}
+
+  @ApiOperation({ summary: 'Retrieves menus categories' })
+  @Get()
+  @UseGuards(AuthGuard('jwt'))
+  findAll() {
+    return this._menuCategoryService.findAll();
+  }
+
+  @ApiOperation({ summary: 'Create menu category' })
+  @Post()
+  @UseGuards(AuthGuard('jwt'))
+  create(@Body() createMenuCategoryDto: CreateMenuCategoryDto) {
+    return this._menuCategoryService.create(createMenuCategoryDto);
+  }
+
+  @ApiOperation({ summary: 'Retrieves one menu category' })
+  @Get(':id')
+  @UseGuards(AuthGuard('jwt'))
+  findOne(@Param('id') id: number) {
+    return this._menuCategoryService.findOne(+id);
+  }
+
+  @ApiOperation({ summary: 'Update menu category' })
+  @Put(':id')
+  @UseGuards(AuthGuard('jwt'))
+  update(@Param('id') id: number, @Body() updateMenuCategoryDto: UpdateMenuCategoryDto) {
+    return this._menuCategoryService.update(id, updateMenuCategoryDto);
+  }
+}

--- a/src/modules/menu-category/menu-category.entity.ts
+++ b/src/modules/menu-category/menu-category.entity.ts
@@ -6,7 +6,7 @@ export class MenuCategory extends BaseEntity {
   id: number;
   @Column({ type: 'varchar', name: 'name', length: 50 })
   name: string;
-  @Column({ name: 'author_id', nullable: true })
+  @Column({ name: 'author_id', nullable: false })
   authorId: number;
   @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
   createdAt: Date;

--- a/src/modules/menu-category/menu-category.entity.ts
+++ b/src/modules/menu-category/menu-category.entity.ts
@@ -1,0 +1,15 @@
+import { BaseEntity, Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+@Entity('menu_categories')
+export class MenuCategory extends BaseEntity {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+  @Column({ type: 'varchar', name: 'name', length: 50 })
+  name: string;
+  @Column({ name: 'author_id', nullable: true })
+  authorId: number;
+  @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
+  createdAt: Date;
+  @UpdateDateColumn({ type: 'timestamp', name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/modules/menu-category/menu-category.module.ts
+++ b/src/modules/menu-category/menu-category.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MenuCategoryService } from './menu-category.service';
+import { MenuCategoryController } from './menu-category.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MenuCategoryRepository } from './menu-category.respository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MenuCategoryRepository])],
+  controllers: [MenuCategoryController],
+  providers: [MenuCategoryService]
+})
+export class MenuCategoryModule {}

--- a/src/modules/menu-category/menu-category.respository.ts
+++ b/src/modules/menu-category/menu-category.respository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { MenuCategory } from './menu-category.entity';
+
+@EntityRepository(MenuCategory)
+export class MenuCategoryRepository extends Repository<MenuCategory> {}

--- a/src/modules/menu-category/menu-category.service.ts
+++ b/src/modules/menu-category/menu-category.service.ts
@@ -26,12 +26,7 @@ export class MenuCategoryService {
     if (menuCategory) throw new ConflictException('menu_category_name_already_exists');
 
     const theMenuCategory = plainToClass(MenuCategory, newMenuCategory);
-    const timestamps = new Date();
-
-    theMenuCategory.createdAt = timestamps;
-    theMenuCategory.updatedAt = timestamps;
     theMenuCategory.authorId = 1;
-
     return plainToClass(ResponseMenuCategoryDto, await theMenuCategory.save());
   }
 
@@ -41,7 +36,6 @@ export class MenuCategoryService {
     if (!menuCategory) throw new ConflictException('menu_category_was_not_found');
 
     menuCategory.name = updateMenuCategoryDto.name;
-    menuCategory.updatedAt = new Date();
 
     return plainToClass(ResponseMenuCategoryDto, await menuCategory.save());
   }

--- a/src/modules/menu-category/menu-category.service.ts
+++ b/src/modules/menu-category/menu-category.service.ts
@@ -1,0 +1,48 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { plainToClass } from 'class-transformer';
+import { CreateMenuCategoryDto } from './dto/create-menu-category.dto';
+import { ResponseMenuCategoryDto } from './dto/response-menu-category.dto';
+import { UpdateMenuCategoryDto } from './dto/update-menu-category.dto';
+import { MenuCategory } from './menu-category.entity';
+import { MenuCategoryRepository } from './menu-category.respository';
+
+@Injectable()
+export class MenuCategoryService {
+
+  constructor(private readonly _menuCategoryRepository: MenuCategoryRepository) {}
+
+  async findAll(): Promise<ResponseMenuCategoryDto[]> {
+    const menuCategories = await this._menuCategoryRepository.find();
+    return menuCategories.map( el => plainToClass(ResponseMenuCategoryDto, el));
+  }
+
+  async findOne(id: number): Promise<ResponseMenuCategoryDto> {
+    return plainToClass(ResponseMenuCategoryDto, await this._menuCategoryRepository.findOne(id));
+  }
+
+  async create(newMenuCategory: CreateMenuCategoryDto) {
+    const menuCategory = await this._menuCategoryRepository.findOne({ name: newMenuCategory.name });
+
+    if (menuCategory) throw new ConflictException('menu_category_name_already_exists');
+
+    const theMenuCategory = plainToClass(MenuCategory, newMenuCategory);
+    const timestamps = new Date();
+
+    theMenuCategory.createdAt = timestamps;
+    theMenuCategory.updatedAt = timestamps;
+    theMenuCategory.authorId = 1;
+
+    return plainToClass(ResponseMenuCategoryDto, await theMenuCategory.save());
+  }
+
+  async update(id: number, updateMenuCategoryDto: UpdateMenuCategoryDto) {
+    const menuCategory = await this._menuCategoryRepository.findOne(id);
+
+    if (!menuCategory) throw new ConflictException('menu_category_was_not_found');
+
+    menuCategory.name = updateMenuCategoryDto.name;
+    menuCategory.updatedAt = new Date();
+
+    return plainToClass(ResponseMenuCategoryDto, await menuCategory.save());
+  }
+}


### PR DESCRIPTION
I finished the menu categories module 
## Taks
- Migration to create menu_categories table
- List all Categories ✅
- Create Categories ✅
- Get one category ✅
- Update Category ✅

## Helpers
I added the endpoint to FastOrder postman team under **MenuCategories** collection , so you can test it.